### PR TITLE
fixed inability to pre-assign fomod selection values according to preset

### DIFF
--- a/InstallScripting/XmlScript/XmlScriptExecutor.cs
+++ b/InstallScripting/XmlScript/XmlScriptExecutor.cs
@@ -248,12 +248,11 @@ namespace FomodInstaller.Scripting.XmlScript
                     bool setFirst = group.Type == OptionGroupType.SelectExactlyOne;
                     foreach (Option option in group.Options)
                     {
-                        bool hasPresetValue = ((groupPreset != null) && groupPreset.HasValue && groupPreset.Value.choices.Any (preChoice => preChoice.name == option.Name));
                         OptionType type = resolveOptionType(option);
                         if ((type == OptionType.Required)
                             || (type == OptionType.Recommended)
                             || (group.Type == OptionGroupType.SelectAll)
-                            || hasPresetValue)
+                            || ((groupPreset != null) && groupPreset.HasValue && groupPreset.Value.choices.Any(preChoice => preChoice.name == option.Name)))
                         {
                             // in case there are multiple recommended options in a group that only
                             // supports one selection, disable all other options, otherwise we would
@@ -270,12 +269,11 @@ namespace FomodInstaller.Scripting.XmlScript
 
                             setFirst = false;
 
-                            if (groupPreset != null && groupPreset.HasValue && !hasPresetValue)
+                            if ((groupPreset != null) && groupPreset.HasValue && !groupPreset.Value.choices.Any(preChoice => preChoice.name == option.Name))
                             {
                                 // We have a groupPreset setting available and this option is _not_
                                 //  part of it - disable the option.
                                 disableOption(option);
-                                continue;
                             } else {
                                 enableOption (option);
                             }

--- a/ModInstallerIPC/Server.cs
+++ b/ModInstallerIPC/Server.cs
@@ -548,7 +548,7 @@ namespace ModInstallerIPC
             dynamic choices;
             try
             {
-                choices = data["choices"];
+                choices = data["choices"] != null ? data["choices"] : data["fomodChoices"];
             }
             catch (RuntimeBinderException) {
                 choices = null;

--- a/ModInstallerIPC/Server.cs
+++ b/ModInstallerIPC/Server.cs
@@ -548,7 +548,7 @@ namespace ModInstallerIPC
             dynamic choices;
             try
             {
-                choices = data["choices"] != null ? data["choices"] : data["fomodChoices"];
+                choices = data["fomodChoices"];
             }
             catch (RuntimeBinderException) {
                 choices = null;


### PR DESCRIPTION
A preset of preselected options is generated when re-installing a mod or
when installing it through a collection (when applicable); this preset
is supposed to be used either pre-select options within the fomod's UI
when re-installing a mod manually; or to restore options selected by a
collection's curator onto a user's mod setup.

This preset was being ignored causing inconsistencies between curator
and user; and/or when re-installing a mod (while attending the
installation)