### PR TITLE
fix build command args for non-windows runtime IDs

### DIFF
--- a/build.js
+++ b/build.js
@@ -69,13 +69,19 @@ async function main() {
     // await dotnet(['restore']);
     // await dotnet(['build', '-c', buildType]);
     await fsExtra.remove(path.join(__dirname, 'dist'));
-    // const args = ['publish', '-c', buildType, '--self-contained', '-r', 'win-x64', '-o', 'dist'];
-    const args = ['publish', '-c', buildType, '--no-self-contained', '-r', 'win-x64', '-o', 'dist'];
+    const args = ['publish', '-c', buildType, '--no-self-contained'];
+    if (process.platform === 'win32'){
+      args.push('-r', 'win-x64');
+    } else if (process.platform != 'android' && process.platform != 'linux'){
+      throw new Error('.NET RID for ' + process.report.getReport().header.osName + ' Not Yet Implemented');
+    } else {
+      args.push('-r', process.platform + '-' + process.arch);
+    }
+    args.push('-o', 'dist');
     if (!debugBuild) {
       args.push('/p:DebugType=None', '/p:DebugSymbols=false');
     }
     await dotnet(args);
-    // await dotnet(['publish', '-c', 'Release', '-a', 'x64', '-o', 'dist']);
     await sign('dist\\ModInstallerIPC.exe');
   } catch (err) {
     const error = ERROR_CODE_HANDLER[err?.code] !== undefined


### PR DESCRIPTION
Not all platforms will be supported, but this will at least provide a human readable error indicating why building failed.