### PR TITLE
Added: API to Initialize FomodInstaller.Interface.Mod without loading script under the hood.

### DIFF
--- a/FomodInstaller.Interface/FomodInstaller.Interface.csproj
+++ b/FomodInstaller.Interface/FomodInstaller.Interface.csproj
@@ -2,16 +2,17 @@
 
   <!-- NuGet Package Shared Details -->
   <Import Project="$([MSBuild]::GetPathOfFileAbove('NuGet.Build.props', '$(MSBuildThisFileDirectory)../'))" />
-  
+
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <Title>FOMOD Installer Library</Title>
+    <Version>1.1.0</Version>
     <Description>Front-end interface for Nexus Mods' FOMOD installer implementation.</Description>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\Utils\Utils.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Just a tiny addition to the API that's needed for NMA.

Includes the following changes:
- Added `Mod.InitializeWithoutLoadingScript` API to initialize the `Mod` item without loading a script from disk under the hood.
    - So we can use our own script from the cache.
- Bumps version of `FomodInstaller.Interface` to 1.1.0

# Backwards Compatibility

- No Breaking API Changes