### PR TITLE
fix: normalize path separators at XML parse time

### DIFF
--- a/src/InstallScripting/XmlScript/Parsers/Parser10.cs
+++ b/src/InstallScripting/XmlScript/Parsers/Parser10.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Xml.Linq;
 using System.Xml.Schema;
 using System.Xml.XPath;
+using Utils;
 
 namespace FomodInstaller.Scripting.XmlScript.Parsers
 {
@@ -217,8 +218,10 @@ namespace FomodInstaller.Scripting.XmlScript.Parsers
 			List<InstallableFile> lstFiles = new List<InstallableFile>();
 			foreach (XElement xelFile in p_xeeFiles)
 			{
-				string strSource = xelFile.Attribute("source").Value;
-				string strDest = (xelFile.Attribute("destination") == null) ? strSource : xelFile.Attribute("destination").Value;
+				string strSource = TextUtil.NormalizePath(xelFile.Attribute("source").Value, false, true);
+				string strDest = (xelFile.Attribute("destination") == null)
+					? strSource
+					: TextUtil.NormalizePath(xelFile.Attribute("destination").Value, false, true);
 				bool booAlwaysInstall = Boolean.Parse(xelFile.Attribute("alwaysInstall").Value);
 				bool booInstallIfUsable = Boolean.Parse(xelFile.Attribute("installIfUsable").Value);
 


### PR DESCRIPTION
## Summary

Wraps \`source\` and \`destination\` attribute extraction in \`Parser10.cs\` with \`TextUtil.NormalizePath()\` at parse time, converting backslash separators to forward-slashes before they enter the instruction pipeline.

\`Parser20\`–\`Parser50\` inherit \`ReadFileInfo()\` from \`Parser10\`, so the fix propagates automatically to all schema versions.

## Motivation

On Linux (case-sensitive, forward-slash filesystem), FOMOD XML files may use Windows-style backslash paths (e.g. \`source="Data\Textures\foo.dds"\`). These paths were passed verbatim into copy instructions and then used for archive lookups — causing mismatches and silent partial installs.

Normalizing at parse time is the right fix: it's the earliest possible point, it's consistent with how \`Mod.cs\` and \`ScriptFunctionProxy.cs\` already treat paths, and it has zero effect on Windows (forward-slashes are already valid there).

## Change

**\`src/InstallScripting/XmlScript/Parsers/Parser10.cs\`** (+5, -2)

- Add \`using Utils;\` directive
- Wrap \`source\` attribute value in \`TextUtil.NormalizePath(value, false, true)\`
- Wrap \`destination\` attribute value in \`TextUtil.NormalizePath(value, false, true)\`
  - \`dirTerminate: false\` — files, not directories
  - \`alternateSeparators: true\` — convert \`\\\` → \`/\`
  - \`toLower: true\` (default) — lowercase for case-insensitive matching

## Risk

Minimal. \`TextUtil.NormalizePath\` is already used throughout the codebase for exactly this purpose. Forward-slash paths are valid on Windows. No behavioral change on Windows-only installs.

## Part of series

This is **fi-1** of a Linux compatibility series. \`fi-2\` (archive case-path emission) depends on this fix being in place.

---

> **Note:** This PR is part of a broader Linux port effort being developed at https://github.com/atabisz/Vortex. The goal is to get Vortex launching on Linux without breaking the existing Windows build — platform-guarded additions, no large refactors. Individual fixes will be submitted as upstream PRs as they stabilize. Feedback welcome.