### PR TITLE
docs: add Linux notes — C# script limitation and native AOT path

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,19 @@ There are two ways to consume it from Node.js:
 - **IPC** (`@nexusmods/fomod-installer-ipc`) -- spawns a .NET process and communicates over stdin/stdout. Supports the full feature set including C# scripts (Windows only).
 - **Native** (`@nexusmods/fomod-installer-native`) -- loads a Native AOT compiled shared library via N-API. Lighter weight, no .NET runtime required, but limited to XML scripts.
 
+## Linux notes
+
+**C# script FOMADs are not supported on Linux.** The .NET C# script engine depends on Windows-only assemblies (`System.Windows.Forms`, `System.Drawing.Common`, Windows registry APIs). On Linux, the installer emits an `UnsupportedFunctionalityWarning` instruction with `reason` and `platform` fields instead of crashing. Callers should display this warning to the user. XML-based FOMADs (the vast majority) work normally on all platforms.
+
+**Recommended Linux path:** Use the native AOT package (`@nexusmods/fomod-installer-native`). It loads a precompiled shared library via N-API with no .NET runtime dependency. It supports XML scripts only, which covers the vast majority of FOMOD mods.
+
+**IPC on Linux:** The IPC package (`@nexusmods/fomod-installer-ipc`) ships a self-contained Linux ELF binary from v0.13.0+. The IPC path works on Linux for XML script FOMADs, but C# scripts still do not execute (the warning is emitted instead).
+
+**Vortex workarounds that can be removed** after this fork's fixes land:
+
+- `replaceAll("\\", "/")` at `InstallManager.ts:7923-7924` — path normalization is now handled at parse time in the installer (PATH-01)
+- `resolvePathCase()` at `InstallManager.ts:7929` — can remain as a safety net, but the installer now emits archive-case paths directly (PATH-02)
+
 ## Project structure
 
 ```


### PR DESCRIPTION
## Summary

Adds a Linux section to the README documenting two facts that aren't obvious from the code:

1. **C# FOMOD scripts are not supported on Linux** — the runtime guard in fi-3 prevents a `TypeLoadException`, but users and integrators should know this upfront rather than getting a warning instruction they don't expect.

2. **The IPC binary is a self-contained native ELF on Linux** — no .NET runtime install required; CI builds it via `dotnet publish -r linux-x64 --self-contained true`.

## Change

**`README.md`** — +13 lines
- New "Linux" section under platform notes
- C# script limitation explained with the `UnsupportedFunctionalityWarning` callout
- Native AOT/self-contained build path noted for integrators

## Risk

None — documentation only.

## Part of series

**fi-5** of a Linux compatibility series. Independent; can land with fi-3 or fi-4.

---

> **Note:** This PR is part of a broader Linux port effort being developed at https://github.com/atabisz/Vortex. The goal is to get Vortex launching on Linux without breaking the existing Windows build — platform-guarded additions, no large refactors. Individual fixes will be submitted as upstream PRs as they stabilize. Feedback welcome.