### PR TITLE
tolerate missing keys in preset dictionaries

### DIFF
--- a/src/InstallScripting/XmlScript/XmlScriptExecutor.cs
+++ b/src/InstallScripting/XmlScript/XmlScriptExecutor.cs
@@ -499,7 +499,7 @@ namespace FomodInstaller.Scripting.XmlScript
                     return new List<OptionsPresetChoice>();
                 }
 
-                return choiceIn.Select(choice => new OptionsPresetChoice {name = Convert.ToString(choice.GetValueOrDefault("name")), idx = Convert.ToInt32(choice.GetValueOrDefault("idx"))});
+                return choiceIn.Select(choice => new OptionsPresetChoice {name = Convert.ToString(choice.GetValueOrDefault("name")) ?? string.Empty, idx = Convert.ToInt32(choice.GetValueOrDefault("idx"))});
             }
 
             IEnumerable<OptionsPresetGroup> ConvertGroups(IEnumerable<Dictionary<string, object>> groupsIn)

--- a/src/InstallScripting/XmlScript/XmlScriptExecutor.cs
+++ b/src/InstallScripting/XmlScript/XmlScriptExecutor.cs
@@ -499,7 +499,7 @@ namespace FomodInstaller.Scripting.XmlScript
                     return new List<OptionsPresetChoice>();
                 }
 
-                return choiceIn.Select(choice => new OptionsPresetChoice {name = Convert.ToString(choice["name"]), idx = Convert.ToInt32(choice["idx"])});
+                return choiceIn.Select(choice => new OptionsPresetChoice {name = Convert.ToString(choice.GetValueOrDefault("name")), idx = Convert.ToInt32(choice.GetValueOrDefault("idx"))});
             }
 
             IEnumerable<OptionsPresetGroup> ConvertGroups(IEnumerable<Dictionary<string, object>> groupsIn)
@@ -511,8 +511,8 @@ namespace FomodInstaller.Scripting.XmlScript
 
                 return groupsIn.Select(group =>
                 {
-                    var choices = (group["choices"] as IEnumerable<object>)?.OfType<Dictionary<string, object>>();
-                    return new OptionsPresetGroup {name = Convert.ToString(group["name"]) ?? string.Empty, choices = ConvertChoices(choices ?? []).ToArray()};
+                    var choices = (group.GetValueOrDefault("choices") as IEnumerable<object>)?.OfType<Dictionary<string, object>>();
+                    return new OptionsPresetGroup {name = Convert.ToString(group.GetValueOrDefault("name")) ?? string.Empty, choices = ConvertChoices(choices ?? []).ToArray()};
                 });
             }
 
@@ -520,8 +520,8 @@ namespace FomodInstaller.Scripting.XmlScript
             {
                 return stepsIn.Select(step =>
                 {
-                    var groups = (step["groups"] as IEnumerable<object>)?.OfType<Dictionary<string, object>>();
-                    return new OptionsPresetStep {name = Convert.ToString(step["name"]) ?? string.Empty, groups = ConvertGroups(groups ?? []).ToArray(),};
+                    var groups = (step.GetValueOrDefault("groups") as IEnumerable<object>)?.OfType<Dictionary<string, object>>();
+                    return new OptionsPresetStep {name = Convert.ToString(step.GetValueOrDefault("name")) ?? string.Empty, groups = ConvertGroups(groups ?? []).ToArray(),};
                 });
             }
 

--- a/src/ModInstaller.IPC.TypeScript/package.json
+++ b/src/ModInstaller.IPC.TypeScript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexusmods/fomod-installer-ipc",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Installer for xml and c# fomods",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/ModInstaller.Native.TypeScript/package.json
+++ b/src/ModInstaller.Native.TypeScript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexusmods/fomod-installer-native",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Package of native bindings bundled with TS declarations",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/test/ModInstaller.Adaptor.Typed.Tests/InstallTests.cs
+++ b/test/ModInstaller.Adaptor.Typed.Tests/InstallTests.cs
@@ -105,9 +105,11 @@ public class InstallTests
         var presetSteps = data.Preset.RootElement.EnumerateArray().ToList();
         foreach (var snapshot in preselectUI.StepSnapshots)
         {
-            // Find preset entry for this step (by name)
+            // Find preset entry for this step (by name). Use TryGetProperty so
+            // malformed preset entries (missing keys) don't crash the test — the
+            // production code tolerates them and the test should too.
             var matchingPresetStep = presetSteps
-                .Where(ps => ps.GetProperty("name").GetString() == snapshot.StepName)
+                .Where(ps => ps.TryGetProperty("name", out var n) && n.GetString() == snapshot.StepName)
                 .ToList();
 
             if (matchingPresetStep.Count == 0)
@@ -115,10 +117,17 @@ public class InstallTests
 
             foreach (var presetStep in matchingPresetStep)
             {
-                foreach (var presetGroup in presetStep.GetProperty("groups").EnumerateArray())
+                if (!presetStep.TryGetProperty("groups", out var presetGroups))
+                    continue;
+                foreach (var presetGroup in presetGroups.EnumerateArray())
                 {
-                    var groupName = presetGroup.GetProperty("name").GetString();
-                    var presetChoiceNames = presetGroup.GetProperty("choices").EnumerateArray()
+                    if (!presetGroup.TryGetProperty("name", out var groupNameProp))
+                        continue;
+                    var groupName = groupNameProp.GetString();
+                    if (!presetGroup.TryGetProperty("choices", out var presetChoices))
+                        continue;
+                    var presetChoiceNames = presetChoices.EnumerateArray()
+                        .Where(c => c.TryGetProperty("name", out _))
                         .Select(c => c.GetProperty("name").GetString())
                         .ToHashSet();
 

--- a/test/TestData/Shared/fallout4.json
+++ b/test/TestData/Shared/fallout4.json
@@ -158,6 +158,55 @@
         { "type": "copy", "source": "02 Improved Map with Visible Roads - Darker\\Textures\\interface\\pip-boy\\worldmap_d.dds", "destination": "Textures\\interface\\pip-boy\\worldmap_d.dds" },
         { "type": "enableallplugins" }
       ]
+    },
+    {
+      "name": "Improved Map - Default (preset with malformed entries)",
+      "mod": "Improved Map with Visible Roads",
+      "archiveFile": "Improved Map with Visible Roads 2.0-1215-2-0.zip",
+      "pluginPath": "Data",
+      "appVersion": "1.0.0",
+      "gameVersion": "1.10.163.0",
+      "extenderVersion": "0.6.21",
+      "installedPlugins": [],
+      "preset": [
+        {"name":"Install Improved Map with Visible Roads","groups":[
+          {"name":"Improved Map with Visible Roads","choices":[
+            {"name":"Default","idx":0},
+            {}
+          ]},
+          {}
+        ]},
+        {}
+      ],
+      "validate": true,
+      "expectedMessage": "Installation successful",
+      "expectedInstructions": [
+        { "type": "copy", "source": "01 Improved Map with Visible Roads - Default\\Textures\\interface\\pip-boy\\worldmap_d.dds", "destination": "Textures\\interface\\pip-boy\\worldmap_d.dds" },
+        { "type": "enableallplugins" }
+      ]
+    },
+    {
+      "name": "Improved Map - Default (preset with mismatched names)",
+      "mod": "Improved Map with Visible Roads",
+      "archiveFile": "Improved Map with Visible Roads 2.0-1215-2-0.zip",
+      "pluginPath": "Data",
+      "appVersion": "1.0.0",
+      "gameVersion": "1.10.163.0",
+      "extenderVersion": "0.6.21",
+      "installedPlugins": [],
+      "preset": [
+        {"name":"Step that no longer exists","groups":[
+          {"name":"Group that no longer exists","choices":[
+            {"name":"Choice that no longer exists","idx":0}
+          ]}
+        ]}
+      ],
+      "validate": true,
+      "expectedMessage": "Installation successful",
+      "expectedInstructions": [
+        { "type": "copy", "source": "01 Improved Map with Visible Roads - Default\\Textures\\interface\\pip-boy\\worldmap_d.dds", "destination": "Textures\\interface\\pip-boy\\worldmap_d.dds" },
+        { "type": "enableallplugins" }
+      ]
     }
   ]
 }


### PR DESCRIPTION
convertPreset(IEnumerable<Dictionary<string,object>>) threw KeyNotFoundException when a saved preset referenced a step, group or choice that no longer exists in the current XML script (e.g. after the mod author renamed/removed a step). Switched raw indexer access to GetValueOrDefault so missing keys fall through to the existing null-safe Convert.ToString / Convert.ToInt32 / null-coalesce handling.

fixes https://linear.app/nexus-mods/issue/APP-379