### PR TITLE
copy ModInstaller.Native.dll into build output so node-gyp builds load

### DIFF
--- a/src/ModInstaller.Native.TypeScript/binding.gyp
+++ b/src/ModInstaller.Native.TypeScript/binding.gyp
@@ -30,6 +30,14 @@
                     ],
                     "ldflags": [
                         "-Wl,-rpath,<(module_root_dir)"
+                    ],
+                    "copies": [
+                        {
+                            "destination": "<(PRODUCT_DIR)",
+                            "files": [
+                                "<(module_root_dir)/ModInstaller.Native.so"
+                            ]
+                        }
                     ]
                 }]
             ],

--- a/src/ModInstaller.Native.TypeScript/binding.gyp
+++ b/src/ModInstaller.Native.TypeScript/binding.gyp
@@ -13,6 +13,14 @@
                 ["OS=='win'", {
                     "libraries": [
                         "<(module_root_dir)/ModInstaller.Native.lib"
+                    ],
+                    "copies": [
+                        {
+                            "destination": "<(PRODUCT_DIR)",
+                            "files": [
+                                "<(module_root_dir)/ModInstaller.Native.dll"
+                            ]
+                        }
                     ]
                 }],
                 ["OS=='linux'", {

--- a/src/ModInstaller.Native.TypeScript/package.json
+++ b/src/ModInstaller.Native.TypeScript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexusmods/fomod-installer-native",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Package of native bindings bundled with TS declarations",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
The built addon depends on ModInstaller.Native.dll/.so at load time, but the binary was never co-located in build/Release. Windows has no rpath and only searches the .node's own directory for dependents, so when node-gyp-build resolves build/Release (which it prefers, e.g. after a downstream electron-rebuild) the addon fails to load with ERR_DLOPEN_FAILED.

Add a gyp copies step to place the binary into PRODUCT_DIR (build/Release) during the build.

part of app-483